### PR TITLE
Added tab showing keyboard shortcuts and keyboard modifier selector

### DIFF
--- a/ScrcpyGui/lib/main.dart
+++ b/ScrcpyGui/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:scrcpy_gui_prod/pages/scripts_page.dart';
 import 'package:scrcpy_gui_prod/pages/favorites_page.dart';
 import 'package:scrcpy_gui_prod/pages/resources_page.dart';
 import 'package:scrcpy_gui_prod/pages/settings_page.dart';
+import 'package:scrcpy_gui_prod/pages/shortcuts_page.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'models/settings_model.dart';
@@ -137,18 +138,21 @@ class _ScrcpyGuiAppState extends State<ScrcpyGuiApp> {
   /// - 1: FavoritesPage - Saved commands and most used commands
   /// - 2: ScriptsPage - File explorer for scripts (.bat/.cmd on Windows, .sh/.command on macOS/Linux)
   /// - 3: ResourcesPage - Documentation, links, and helpful commands
-  /// - 4: SettingsPage - Application preferences and panel customization
+  /// - 4: ShortcutsPage - Scrcpy keyboard and mouse shortcuts
+  /// - 5: SettingsPage - Application preferences and panel customization
   ///
   /// Index mapping (when Scripts tab is hidden):
   /// - 0: HomePage - Command builder with configurable panels
   /// - 1: FavoritesPage - Saved commands and most used commands
   /// - 2: ResourcesPage - Documentation, links, and helpful commands
-  /// - 3: SettingsPage - Application preferences and panel customization
+  /// - 3: ShortcutsPage - Scrcpy keyboard and mouse shortcuts
+  /// - 4: SettingsPage - Application preferences and panel customization
   List<Widget> get pages => [
         HomePage(panelOrder: _currentSettings.panelOrder),
         const FavoritesPage(),
         if (_currentSettings.showBatFilesTab) const ScriptsPage(),
         const ResourcesPage(),
+        const ShortcutsPage(),
         const SettingsPage(),
       ];
 

--- a/ScrcpyGui/lib/models/scrcpy_options.dart
+++ b/ScrcpyGui/lib/models/scrcpy_options.dart
@@ -350,6 +350,7 @@ class InputControlOptions {
   String mouseBind;
   String keyboardMode;
   String mouseMode;
+  List<String> shortcutMod;
 
   InputControlOptions({
     this.noControl = false,
@@ -362,6 +363,7 @@ class InputControlOptions {
     this.mouseBind = '',
     this.keyboardMode = '',
     this.mouseMode = '',
+    this.shortcutMod = const [],
   });
 
   InputControlOptions copyWith({
@@ -375,6 +377,7 @@ class InputControlOptions {
     String? mouseBind,
     String? keyboardMode,
     String? mouseMode,
+    List<String>? shortcutMod,
   }) {
     return InputControlOptions(
       noControl: noControl ?? this.noControl,
@@ -387,6 +390,7 @@ class InputControlOptions {
       mouseBind: mouseBind ?? this.mouseBind,
       keyboardMode: keyboardMode ?? this.keyboardMode,
       mouseMode: mouseMode ?? this.mouseMode,
+      shortcutMod: shortcutMod ?? this.shortcutMod,
     );
   }
 
@@ -402,6 +406,7 @@ class InputControlOptions {
     if (rawKeyEvents) cmd += ' --raw-key-events';
     if (preferText) cmd += ' --prefer-text';
     if (mouseBind.isNotEmpty) cmd += ' --mouse-bind=$mouseBind';
+    if (shortcutMod.isNotEmpty) cmd += ' --shortcut-mod=${shortcutMod.join(',')}';
     debugPrint('[InputControlOptions] => $cmd');
     return cmd.trim();
   }

--- a/ScrcpyGui/lib/pages/home_panels/input_control_panel.dart
+++ b/ScrcpyGui/lib/pages/home_panels/input_control_panel.dart
@@ -5,9 +5,11 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:multi_dropdown/multi_dropdown.dart';
 import 'package:provider/provider.dart';
 
 import '../../services/command_builder_service.dart';
+import '../../theme/app_colors.dart';
 import '../../utils/clear_notifier.dart';
 import '../../widgets/custom_checkbox.dart';
 import '../../widgets/custom_searchbar.dart';
@@ -47,6 +49,19 @@ class _InputControlPanelState extends State<InputControlPanel> {
   String? mouseBind;
   String? keyboardMode;
   String? mouseMode;
+  List<String> shortcutMod = [];
+
+  final MultiSelectController<String> _shortcutModController =
+      MultiSelectController<String>();
+
+  final List<DropdownItem<String>> _shortcutModItems = [
+    DropdownItem(label: 'lctrl', value: 'lctrl'),
+    DropdownItem(label: 'rctrl', value: 'rctrl'),
+    DropdownItem(label: 'lalt', value: 'lalt'),
+    DropdownItem(label: 'ralt', value: 'ralt'),
+    DropdownItem(label: 'lsuper', value: 'lsuper'),
+    DropdownItem(label: 'rsuper', value: 'rsuper'),
+  ];
 
   final List<String> mouseBindOptions = [
     'bhsm',
@@ -88,6 +103,7 @@ class _InputControlPanelState extends State<InputControlPanel> {
       rawKeyEvents: rawKeyEvents,
       preferText: preferText,
       mouseBind: mouseBind ?? '',
+      shortcutMod: shortcutMod,
     );
 
     cmdService.updateInputControlOptions(options);
@@ -109,7 +125,9 @@ class _InputControlPanelState extends State<InputControlPanel> {
       rawKeyEvents = false;
       preferText = false;
       mouseBind = null;
+      shortcutMod = [];
     });
+    _shortcutModController.clearAll();
     _updateService(context);
   }
 
@@ -275,6 +293,59 @@ class _InputControlPanelState extends State<InputControlPanel> {
                   tooltip: 'Configure bindings of secondary clicks. Each character maps a mouse button: + (forward), - (ignore), b (BACK), h (HOME), s (APP_SWITCH), n (notifications).',
                 ),
               ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: Tooltip(
+                  message: 'Select one or more modifier keys used for scrcpy shortcuts (e.g. lctrl+rctrl). Defaults to left Alt or left Super if not set.',
+                  child: MultiDropdown<String>(
+              items: _shortcutModItems,
+              controller: _shortcutModController,
+              onSelectionChange: (selected) {
+                setState(() {
+                  shortcutMod = selected.toList();
+                });
+                _updateService(context);
+              },
+              fieldDecoration: FieldDecoration(
+                hintText: 'Shortcut Mod Key',
+                hintStyle: const TextStyle(color: AppColors.textSecondary, fontSize: 14),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: AppColors.textSecondary.withValues(alpha: 0.3)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: AppColors.primary),
+                ),
+                backgroundColor: AppColors.background,
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              ),
+              dropdownDecoration: DropdownDecoration(
+                backgroundColor: AppColors.surface,
+                maxHeight: 250,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              dropdownItemDecoration: DropdownItemDecoration(
+                selectedBackgroundColor: AppColors.primary.withValues(alpha: 0.15),
+                textColor: Colors.white70,
+                selectedTextColor: Colors.white,
+              ),
+              chipDecoration: ChipDecoration(
+                backgroundColor: AppColors.primary.withValues(alpha: 0.2),
+                labelStyle: const TextStyle(color: Colors.white, fontSize: 13),
+                borderRadius: BorderRadius.circular(6),
+                deleteIcon: const Icon(Icons.close, size: 16, color: Colors.white70),
+                spacing: 6,
+                runSpacing: 6,
+              ),
+              ),
+            ),
+          ),
+              const Spacer(flex: 2),
             ],
           ),
         ],

--- a/ScrcpyGui/lib/pages/shortcuts_page.dart
+++ b/ScrcpyGui/lib/pages/shortcuts_page.dart
@@ -1,0 +1,202 @@
+/// Shortcuts page displaying the official scrcpy keyboard shortcuts.
+///
+/// Fetches the shortcuts markdown from the scrcpy repository and renders
+/// it using [Markdown] from flutter_markdown_plus. The content is cached
+/// locally for offline access and refreshed in the background once per
+/// app session.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import '../services/shortcuts_service.dart';
+import '../theme/app_colors.dart';
+
+class ShortcutsPage extends StatefulWidget {
+  const ShortcutsPage({super.key});
+
+  @override
+  State<ShortcutsPage> createState() => _ShortcutsPageState();
+}
+
+class _ShortcutsPageState extends State<ShortcutsPage> {
+  final ShortcutsService _service = ShortcutsService();
+  String? _markdown;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadContent();
+  }
+
+  Future<void> _loadContent() async {
+    // Try loading from cache first for instant display
+    final cached = await _service.getCachedMarkdown();
+    if (cached != null && mounted) {
+      setState(() {
+        _markdown = cached;
+        _loading = false;
+      });
+    }
+
+    // Refresh from network once per session
+    if (!_service.hasRefreshedThisSession) {
+      _service.markRefreshed();
+      final fresh = await _service.fetchAndCache();
+      if (mounted) {
+        if (fresh != null) {
+          setState(() {
+            _markdown = fresh;
+            _loading = false;
+          });
+        } else if (_markdown == null) {
+          // No cache and no network
+          setState(() {
+            _loading = false;
+            _error = 'Could not load shortcuts. Check your internet connection.';
+          });
+        }
+      }
+    } else if (_markdown == null) {
+      setState(() {
+        _loading = false;
+        _error = 'Could not load shortcuts. Check your internet connection.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: Column(
+        children: [
+          // Header matching Resources page style
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.1),
+              border: Border(
+                bottom: BorderSide(
+                  color: AppColors.primary.withValues(alpha: 0.3),
+                  width: 1,
+                ),
+              ),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: BoxDecoration(
+                    color: AppColors.primary.withValues(alpha: 0.2),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Icon(
+                    Icons.keyboard,
+                    color: AppColors.primary,
+                    size: 20,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                const Text(
+                  'Scrcpy Keyboard & Mouse Shortcuts',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Content area
+          Expanded(
+            child: _buildContent(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_loading) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.primary),
+      );
+    }
+
+    if (_error != null && _markdown == null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.cloud_off, color: AppColors.textSecondary, size: 48),
+            const SizedBox(height: 16),
+            Text(
+              _error!,
+              style: const TextStyle(color: AppColors.textSecondary),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  _loading = true;
+                  _error = null;
+                });
+                _service.markRefreshed();
+                _loadContent();
+              },
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final styleSheet = MarkdownStyleSheet(
+      h1: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.white),
+      h2: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: AppColors.primaryLight),
+      h3: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: AppColors.primaryLight),
+      h4: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold, color: Colors.white),
+      p: const TextStyle(fontSize: 14, color: Colors.white70, height: 1.6),
+      a: const TextStyle(color: AppColors.primary, decoration: TextDecoration.underline),
+      code: TextStyle(
+        fontSize: 13,
+        color: AppColors.primaryLight,
+        backgroundColor: AppColors.surface,
+      ),
+      codeblockDecoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      codeblockPadding: const EdgeInsets.all(12),
+      tableHead: const TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+      tableBody: const TextStyle(color: Colors.white70),
+      tableBorder: TableBorder.all(color: AppColors.divider),
+      tableCellsPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      blockquote: const TextStyle(color: AppColors.textSecondary),
+      blockquoteDecoration: BoxDecoration(
+        border: Border(left: BorderSide(color: AppColors.primary, width: 3)),
+      ),
+      blockquotePadding: const EdgeInsets.only(left: 16, top: 8, bottom: 8),
+      listBullet: const TextStyle(color: Colors.white70),
+      strong: const TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
+      em: const TextStyle(fontStyle: FontStyle.italic, color: Colors.white70),
+      blockSpacing: 12,
+    );
+
+    // Convert <kbd>X</kbd> HTML tags to inline code since flutter_markdown
+    // doesn't render arbitrary HTML elements.
+    final processed = _markdown!.replaceAllMapped(
+      RegExp(r'<kbd>(.*?)</kbd>'),
+      (match) => '`${match.group(1)}`',
+    );
+
+    return Markdown(
+      data: processed,
+      styleSheet: styleSheet,
+      padding: const EdgeInsets.all(32),
+    );
+  }
+}

--- a/ScrcpyGui/lib/services/shortcuts_service.dart
+++ b/ScrcpyGui/lib/services/shortcuts_service.dart
@@ -1,0 +1,65 @@
+/// Service for fetching and caching scrcpy keyboard shortcuts documentation.
+///
+/// Downloads the official shortcuts markdown from the scrcpy repository
+/// and caches it locally for offline access. On each app launch, the first
+/// access attempts a background refresh from the remote source.
+library;
+
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+class ShortcutsService {
+  static const _remoteUrl =
+      'https://raw.githubusercontent.com/Genymobile/scrcpy/refs/heads/master/doc/shortcuts.md';
+  static const _cacheFileName = 'shortcuts_cache.md';
+
+  static ShortcutsService? _instance;
+  factory ShortcutsService() => _instance ??= ShortcutsService._();
+  ShortcutsService._();
+
+  String? _cachedMarkdown;
+  bool _hasRefreshedThisSession = false;
+
+  /// Returns the cached markdown content, loading from disk if needed.
+  Future<String?> getCachedMarkdown() async {
+    if (_cachedMarkdown != null) return _cachedMarkdown;
+    final file = await _cacheFile;
+    if (await file.exists()) {
+      _cachedMarkdown = await file.readAsString();
+      return _cachedMarkdown;
+    }
+    return null;
+  }
+
+  /// Fetches the latest markdown from the remote URL and updates the cache.
+  /// Returns the new content on success, or null on failure.
+  Future<String?> fetchAndCache() async {
+    try {
+      final response = await http
+          .get(Uri.parse(_remoteUrl))
+          .timeout(const Duration(seconds: 15));
+      if (response.statusCode == 200) {
+        final content = response.body;
+        final file = await _cacheFile;
+        await file.writeAsString(content);
+        _cachedMarkdown = content;
+        return content;
+      }
+    } catch (_) {
+      // Network error — caller should fall back to cache
+    }
+    return null;
+  }
+
+  /// Attempts a background refresh once per app session.
+  /// Returns true if a refresh was performed (regardless of success).
+  bool get hasRefreshedThisSession => _hasRefreshedThisSession;
+  void markRefreshed() => _hasRefreshedThisSession = true;
+
+  Future<File> get _cacheFile async {
+    final dir = await getApplicationSupportDirectory();
+    return File(p.join(dir.path, _cacheFileName));
+  }
+}

--- a/ScrcpyGui/lib/widgets/sidebar.dart
+++ b/ScrcpyGui/lib/widgets/sidebar.dart
@@ -47,6 +47,7 @@ class Sidebar extends StatelessWidget {
       if (showBatFilesTab)
         const _SidebarItem(icon: Icons.terminal, label: 'Scripts'),
       const _SidebarItem(icon: Icons.folder, label: 'Resources'),
+      const _SidebarItem(icon: Icons.keyboard, label: 'Shortcuts'),
       const _SidebarItem(icon: Icons.settings, label: 'Settings'),
     ];
 

--- a/ScrcpyGui/pubspec.yaml
+++ b/ScrcpyGui/pubspec.yaml
@@ -39,6 +39,9 @@ dependencies:
   url_launcher: ^6.1.10
   package_info_plus: ^8.0.0
   desktop_drop: ^0.4.4
+  flutter_markdown_plus: ^1.0.7
+  http: ^1.2.0
+  multi_dropdown: ^3.0.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This fetches the official keyboard shortcut page from the scrcpy repo and shows it in a tab.  It caches this so if you are without internet but have grabbed it before it uses the old one.

Added the keyboard modifier key control to the input options as well.